### PR TITLE
SQLite initialization error

### DIFF
--- a/ContosoApp/App.xaml.cs
+++ b/ContosoApp/App.xaml.cs
@@ -108,8 +108,8 @@ namespace Contoso.App
                 File.Copy(demoDatabasePath, databasePath);
             }
             var dbOptions = new DbContextOptionsBuilder<ContosoContext>().UseSqlite(
-                "Data Source=" + databasePath);
-            Repository = new SqlContosoRepository(dbOptions);
+                "Data Source=" + databasePath).Options;
+            Repository = new SqlContosoRepository(new ContosoContext(dbOptions));
         }
 
         /// <summary>


### PR DESCRIPTION
The dbOptions variable should be a DBContextOptions, not a DBContextOptionsBuilder
The SqlContosoRepository class requires a ContosoContext, not a DbContextOptions.